### PR TITLE
Hsp gaps NoMethodError Bug Fix

### DIFF
--- a/lib/bio/db/blast/parser/nokogiri.rb
+++ b/lib/bio/db/blast/parser/nokogiri.rb
@@ -8,9 +8,9 @@ module Bio
     module XPath
       def field name
         res = if @prefix
-          @xml.xpath(@prefix+name+'/text()')
+          @xml.xpath(@prefix+name+'/text()').to_s
         else
-          @xml.xpath(name+'/text()')
+          @xml.xpath(name+'/text()').to_s
         end
         if res == nil
           logger = Bio::Log::LoggerPlus['bio-blastxmlparser']

--- a/lib/bio/db/blast/parser/nokogiri.rb
+++ b/lib/bio/db/blast/parser/nokogiri.rb
@@ -68,6 +68,7 @@ module Bio
                         'Hsp_hit-frame'   => :hit_frame,
                         'Hsp_identity'    => :identity,
                         'Hsp_positive'    => :positive,
+                        'Hsp_gaps'        => :gaps,
                         'Hsp_align-len'   => :align_len
       MapXPath.define_f 'Hsp_bit-score'   => :bit_score,
                         'Hsp_evalue'      => :evalue

--- a/spec/bio-blastxmlparser_spec.rb
+++ b/spec/bio-blastxmlparser_spec.rb
@@ -43,6 +43,7 @@ describe "Bio::Blast::NokogiriBlastXml" do
     hsp.identity.should == 73
     hsp.positive.should == 73
     hsp.align_len.should == 73
+    hsp.gaps.should == 0
     hsp.qseq.should == "AGTGAAGCTTCTAGATATTTGGCGGGTACCTCTAATTTTGCCTGCCTGCCAACCTATATGCTCCTGTGTTTAG"
     hsp.hseq.should == "AGTGAAGCTTCTAGATATTTGGCGGGTACCTCTAATTTTGCCTGCCTGCCAACCTATATGCTCCTGTGTTTAG"
     hsp.midline.should == "|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"

--- a/test/data/nt_example_blastn.m7
+++ b/test/data/nt_example_blastn.m7
@@ -46,6 +46,7 @@
               <Hsp_identity>73</Hsp_identity>
               <Hsp_positive>73</Hsp_positive>
               <Hsp_align-len>73</Hsp_align-len>
+              <Hsp_gaps>0</Hsp_gaps>
               <Hsp_qseq>AGTGAAGCTTCTAGATATTTGGCGGGTACCTCTAATTTTGCCTGCCTGCCAACCTATATGCTCCTGTGTTTAG</Hsp_qseq>
               <Hsp_hseq>AGTGAAGCTTCTAGATATTTGGCGGGTACCTCTAATTTTGCCTGCCTGCCAACCTATATGCTCCTGTGTTTAG</Hsp_hseq>
               <Hsp_midline>|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>


### PR DESCRIPTION
Calling `to_s` on the XML XPath object in `Bio::Blast::XPath.field` fixed a strange bug I was experiencing when calling the `NokogiriBlastHsp` method `gaps`.

Under the gem's current release v1.0.1, when calling `gaps` on a `NokogiriBlastHsp` object I would receive a `NoMethodError: undefined method 'gaps'` while the remaining `NokogiriBlastHsp` methods responding as expected.

View a TravisCI build matrix for details.
http://travis-ci.org/#!/ncgr/quorum/builds/2068717

System Details:
Ubuntu 12.04 local 11.10 TravisCI
NCBI Blast+ 2.2.25
Ruby >= 1.9.2
Rails >= 3.1
Nokogiri 1.5.5

Thanks!
